### PR TITLE
Fixed a bug with prepend()

### DIFF
--- a/source/CsQuery.Tests/Csharp/Methods/Prepend.cs
+++ b/source/CsQuery.Tests/Csharp/Methods/Prepend.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+
+namespace CsQuery.Tests.Csharp
+{
+    public partial class Methods : CsQueryTest
+    {
+        [Test, TestMethod]
+        public void PrependBug()
+        {
+            var result = CQ.CreateFragment("<b>1</b><b>2</b><b>3</b>").Select("b").Prepend("__").Append("__").Text();
+            Assert.AreEqual("__1____2____3__", result);
+        }
+    }
+}

--- a/source/CsQuery.Tests/Csquery.Tests.csproj
+++ b/source/CsQuery.Tests/Csquery.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Csharp\Methods\HasAttr.cs" />
     <Compile Include="Csharp\Methods\Before.cs" />
     <Compile Include="Csharp\Methods\Append.cs" />
+    <Compile Include="Csharp\Methods\Prepend.cs" />
     <Compile Include="Csharp\Methods\Render.cs" />
     <Compile Include="Csharp\Methods\ReplaceWith.cs" />
     <Compile Include="Csharp\Documents\Last.cs" />

--- a/source/CsQuery/CQ_jQuery/Prepend.cs
+++ b/source/CsQuery/CQ_jQuery/Prepend.cs
@@ -111,11 +111,12 @@ namespace CsQuery
             // be insterted. 
 
             List<IDomObject> list = elements.ToList();
-            int index = 0;
             
             foreach (var child in Elements)
             {
-               // Make sure they didn't really mean to add to a tbody or something
+                int index = 0;
+
+                // Make sure they didn't really mean to add to a tbody or something
                 IDomElement target = GetTrueTarget(child );
 
                 foreach (var e in list)


### PR DESCRIPTION
The index variable was not being reset for each element in the source collection.

See http://jsfiddle.net/29WVe/ for jQuery version of the test I added.

Not sure if my test was in the right location or format, feel free to do whatever with it, but hopefully the fix helps :)
