### PR TITLE
Prevent breaking leading xml tag

### DIFF
--- a/source/CsQuery.Tests/Core/OutputFormatters/FormatDefault.cs
+++ b/source/CsQuery.Tests/Core/OutputFormatters/FormatDefault.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+
+namespace CsQuery.Tests.Core.OutputFormatters_
+{
+    [TestFixture, TestClass]
+    class FormatDefault
+    {
+        [Test, TestMethod]
+        public void RenderLeadingXmlTag()
+        {
+            const string XmlTag = @"<?xml version=""1.0"" encoding=""UTF-8""?>";
+
+            var formatter = new Output.FormatDefault();
+            var comment = new CsQuery.Implementation.DomComment(XmlTag);
+            var actual = formatter.Render(comment);
+
+            Assert.AreEqual(XmlTag, actual, "FormatDefault should not change leading xml tag.");
+        }
+    }
+}

--- a/source/CsQuery.Tests/Csquery.Tests.csproj
+++ b/source/CsQuery.Tests/Csquery.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Arrays.cs" />
     <Compile Include="AssertEx.cs" />
     <Compile Include="Core\Documents\MultipleDocs.cs" />
+    <Compile Include="Core\OutputFormatters\FormatDefault.cs" />
     <Compile Include="Core\Dom\DomContainer.cs" />
     <Compile Include="Core\Dom\InnerText.cs" />
     <Compile Include="Core\Dom\DomText.cs" />

--- a/source/CsQuery/Output/OutputFormatterDefault.cs
+++ b/source/CsQuery/Output/OutputFormatterDefault.cs
@@ -430,6 +430,10 @@ namespace CsQuery.Output
             {
                 return;
             }
+            else if (element.NodeValue.StartsWith("<?") && element.NodeValue.EndsWith("?>"))
+            {
+                writer.Write(element.NodeValue);
+            }
             else
             {
                 writer.Write("<!--" + element.NodeValue + "-->");


### PR DESCRIPTION
Hello,

I'm using your tool to build a kind of WebGrabber so I have to handle really many cases.
One of them is the html document with "<?xml ... ?> tag instead of DocType.
It's rendered by any modern browser without errors so I expect the same functionality from CSQuery.
However, default output formatter transorms the tag into "<!--<?xml...?>--> which is handled in incorrect way by browsers.

I suggest the following pull request to fix the issue. I'm sorry for having no time to dig deeper to the root cause why described tag is parsed as html comment.

Short commit description:

1)Prevent Default OutputFormatter from breaking leading xml comment
- As some sites specify leading xml comment tag instead of doctype, xml
  comment tag should not be broken during parsing of any document
- When the comment tag is like <?...?> - simply render it's NodeValue as
  no more wrapping is required
