### PR TITLE
DOM Object Annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ stylecop.*
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
+*.sln.ide
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/source/CsQuery.Tests/Core/Annotations/Annotations.cs
+++ b/source/CsQuery.Tests/Core/Annotations/Annotations.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+
+namespace CsQuery.Tests.Core.Annotations
+{
+    [TestClass, TestFixture]
+    public class Annotations
+    {
+        [TestMethod, Test]
+        public void EmptyByDefault()
+        {
+            var cq = CQ.Create("<div></div>");
+
+            int length = cq.FirstElement().Annotations.Length;
+            Assert.AreEqual(0, length, "annotations is not empty");
+        }
+
+        [TestMethod, Test]
+        public void GetMissingAnnotationReturnsNull()
+        {
+            var cq = CQ.Create("<div></div>");
+            object value = cq.FirstElement().Annotations.GetAnnotation("missing");
+
+            Assert.IsNull(value, "value was not null");
+        }
+
+        [TestMethod, Test]
+        public void CanStoreAnnotations()
+        {
+            var cq = CQ.Create("<div></div>");
+            var div = cq.FirstElement();
+
+            div.Annotations.SetAnnotation("created-by", "User1");
+            div.Annotations.SetAnnotation("times-created", 1);
+
+            Assert.AreEqual(2, div.Annotations.Length, "annotation length is wrong");
+
+            var createdBy = div.Annotations.GetAnnotation("created-by");
+            var timesCreated = div.Annotations.GetAnnotation("times-created");
+
+            Assert.AreEqual("User1", createdBy, "incorect created by value");
+            Assert.AreEqual(1, timesCreated, "incorrect times created value");
+        }
+
+        [TestMethod, Test]
+        public void CanRemoveAnnotations()
+        {
+            var cq = CQ.Create("<div></div>");
+            var div = cq.FirstElement();
+
+            div.Annotations.SetAnnotation("created-by", "User1");
+
+            Assert.AreEqual(1, div.Annotations.Length, "initial annotations length is wrong");
+
+            var createdBy = div.Annotations.GetAnnotation("created-by");
+            Assert.AreEqual("User1", createdBy, "incorect created by value");
+
+            div.Annotations.RemoveAnnotation("created-by");
+
+            Assert.AreEqual(0, div.Annotations.Length, "final annotations length is wrong");
+            Assert.IsNull(div.Annotations.GetAnnotation("created-by"));
+        }
+
+        [TestMethod, Test]
+        public void NullOrWhiteSpaceAnnotationNamesNotPermitted()
+        {
+            var cq = CQ.Create("<div></div>");
+            var a = cq.FirstElement().Annotations;
+
+            Assert.Throws<ArgumentException>(() => a.GetAnnotation(null));
+            Assert.Throws<ArgumentException>(() => a.GetAnnotation(""));
+            Assert.Throws<ArgumentException>(() => a.GetAnnotation(" "));
+            Assert.Throws<ArgumentException>(() => a.GetAnnotation("\t"));
+
+            Assert.Throws<ArgumentException>(() => a.RemoveAnnotation(null));
+            Assert.Throws<ArgumentException>(() => a.RemoveAnnotation(""));
+            Assert.Throws<ArgumentException>(() => a.RemoveAnnotation(" "));
+            Assert.Throws<ArgumentException>(() => a.RemoveAnnotation("\t"));
+
+            Assert.Throws<ArgumentException>(() => a.SetAnnotation(null, "value"));
+            Assert.Throws<ArgumentException>(() => a.SetAnnotation("", "value"));
+            Assert.Throws<ArgumentException>(() => a.SetAnnotation(" ", "value"));
+            Assert.Throws<ArgumentException>(() => a.SetAnnotation("\t", "value"));
+        }
+
+        [TestMethod, Test]
+        public void CanUseIndexerToGetAndSetAnnotations()
+        {
+            var cq = CQ.Create("<div></div>");
+            var a = cq.FirstElement().Annotations;
+
+            Assert.IsNull(a["created-by"], "not initially null");
+
+            a["created-by"] = "User1";
+
+            Assert.AreEqual("User1", a["created-by"], "incorrect value");
+        }
+        
+        [TestMethod, Test]
+        public void CanEnumerateAnnotations()
+        {
+            var cq = CQ.Create("<div></div>");
+            var a = cq.FirstElement().Annotations;
+
+            Assert.AreEqual(0, a.ToArray().Length);
+
+            a["created-by"] = "User1";
+            a["times-created"] = 1;
+
+            var annotations = a.ToArray();
+
+            var correctKeys = annotations.Select(x => x.Key).SequenceEqual(new[] {"created-by", "times-created"});
+            var correctValues = annotations.Select(x => x.Value).SequenceEqual(new object[] {"User1", 1});
+
+            Assert.IsTrue(correctKeys, "incorrect keys");
+            Assert.IsTrue(correctValues, "incorrect values");
+        }
+    }
+}

--- a/source/CsQuery.Tests/Csquery.Tests.csproj
+++ b/source/CsQuery.Tests/Csquery.Tests.csproj
@@ -95,6 +95,7 @@
   <ItemGroup>
     <Compile Include="Arrays.cs" />
     <Compile Include="AssertEx.cs" />
+    <Compile Include="Core\Annotations\Annotations.cs" />
     <Compile Include="Core\Documents\MultipleDocs.cs" />
     <Compile Include="Core\Dom\DomContainer.cs" />
     <Compile Include="Core\Dom\DomObject.cs" />

--- a/source/CsQuery/CsQuery.csproj
+++ b/source/CsQuery/CsQuery.csproj
@@ -175,9 +175,11 @@
     <Compile Include="Dom\HtmlElements\IFormAssociatedElement.cs" />
     <Compile Include="Dom\HtmlElements\IHTMLButtonElement.cs" />
     <Compile Include="Dom\HtmlElements\IHTMLTextAreaElement.cs" />
+    <Compile Include="Dom\IAnnotationCollection.cs" />
     <Compile Include="Dom\ICSSRule.cs" />
     <Compile Include="Dom\ICSSStyleRule.cs" />
     <Compile Include="Dom\ICSSStyleSheet.cs" />
+    <Compile Include="Dom\Implementation\AnnotationCollection.cs" />
     <Compile Include="Dom\Implementation\CSSRule.cs" />
     <Compile Include="Dom\Implementation\CSSStyleChangedArgs.cs" />
     <Compile Include="Dom\Implementation\CSSStyleRule.cs" />

--- a/source/CsQuery/Dom/IAnnotationCollection.cs
+++ b/source/CsQuery/Dom/IAnnotationCollection.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace CsQuery
+{
+    /// <summary>
+    /// Interface for methods to access the custom annotations on a DOM node.
+    /// </summary>
+    public interface IAnnotationCollection : IEnumerable<KeyValuePair<string, object>>
+    {
+        /// <summary>
+        /// Get the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <returns>The annotation value</returns>
+        object GetAnnotation(string name);
+
+        /// <summary>
+        /// Set the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <param name="value">The new annotation value</param>
+        void SetAnnotation(string name, object value);
+
+        /// <summary>
+        /// Removes a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        void RemoveAnnotation(string name);
+
+        /// <summary>
+        /// Gets or sets the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <returns>The annotation value</returns>
+        /// <returntype>object</returntype>
+        object this[string name] { get; set; }
+
+        /// <summary>
+        /// The number of annotations in this annotation collection.
+        /// </summary>
+        /// <returntype>int</returntype>
+        int Length { get; }
+    }
+}

--- a/source/CsQuery/Dom/IDomObject.cs
+++ b/source/CsQuery/Dom/IDomObject.cs
@@ -85,6 +85,12 @@ namespace CsQuery
         string Id { get; set; }
 
         /// <summary>
+        /// An interface to access the annotations collection of this object.
+        /// </summary>
+
+        IAnnotationCollection Annotations { get; }
+
+        /// <summary>
         /// An interface to access the attributes collection of this element.
         /// </summary>
 

--- a/source/CsQuery/Dom/Implementation/AnnotationCollection.cs
+++ b/source/CsQuery/Dom/Implementation/AnnotationCollection.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace CsQuery.Implementation
+{
+    /// <summary>
+    /// A collection of annotations
+    /// </summary>
+    public class AnnotationCollection : IAnnotationCollection
+    {
+        private readonly Dictionary<string, object> _annotations 
+            = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets the enumerator of the annotation collection
+        /// </summary>
+        /// <returns>An enumerator</returns>
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _annotations.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets the enumerator of the annotation collection
+        /// </summary>
+        /// <returns>An enumerator</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Get the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <returns>The annotation value</returns>
+        public object GetAnnotation(string name)
+        {
+            if(String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("You must provide an annotation name.", "name");
+
+            object result;
+            _annotations.TryGetValue(name, out result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <param name="value">The new annotation value</param>
+        public void SetAnnotation(string name, object value)
+        {
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("You must provide an annotation name.", "name");
+
+            _annotations[name] = value;
+        }
+
+        /// <summary>
+        /// Removes a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        public void RemoveAnnotation(string name)
+        {
+            if (String.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("You must provide an annotation name.", "name");
+
+            _annotations.Remove(name);
+        }
+
+        /// <summary>
+        /// Gets or sets the value of a named annotation
+        /// </summary>
+        /// <param name="name">The annotation name</param>
+        /// <returns>The annotation value</returns>
+        /// <returntype>object</returntype>
+        public object this[string name]
+        {
+            get { return GetAnnotation(name); }
+            set { SetAnnotation(name, value); }
+        }
+
+        /// <summary>
+        /// The number of annotations in this annotation collection.
+        /// </summary>
+        /// <returntype>int</returntype>
+        public int Length { get { return _annotations.Count; } }
+    }
+}

--- a/source/CsQuery/Dom/Implementation/DomObject.cs
+++ b/source/CsQuery/Dom/Implementation/DomObject.cs
@@ -89,6 +89,12 @@ namespace CsQuery.Implementation
 
         protected DocumentInfo DocInfo;
 
+        /// <summary>
+        /// The collection of custom annotations applied to this DOM object.  It is initialized when
+        /// it is first accessed;
+        /// </summary>
+        private IAnnotationCollection _annotations;
+
         #endregion
         
         #region public properties
@@ -112,6 +118,14 @@ namespace CsQuery.Implementation
         /// </summary>
 
         public abstract bool InnerHtmlAllowed { get; }
+
+        /// <summary>
+        /// An interface to access the annotations collection of this object.
+        /// </summary>
+        public virtual IAnnotationCollection Annotations
+        {
+            get { return _annotations ?? (_annotations = new AnnotationCollection()); }
+        }
 
         /// <summary>
         /// Gets the identifier of the node name.

--- a/source/CsQuery/Web/ServerConfig.cs
+++ b/source/CsQuery/Web/ServerConfig.cs
@@ -58,10 +58,8 @@ namespace CsQuery.Web
                 {
                     config.UserAgent = options.UserAgent;
                 }
-                if (options.Timeout != null)
-                {
-                    config.Timeout = options.Timeout;
-                }
+
+                config.Timeout = options.Timeout;
             }
             return config;
         }
@@ -80,10 +78,8 @@ namespace CsQuery.Web
         public static void Apply(ServerConfig options, ICsqWebRequest request)
         {
             var opts = Merge(options);
-            if (opts.Timeout != null)
-            {
-                request.Timeout = (int)Math.Floor(opts.Timeout.TotalMilliseconds);
-            }
+            request.Timeout = (int)Math.Floor(opts.Timeout.TotalMilliseconds);
+
             if (opts.UserAgent != null)
             {
                 request.UserAgent = opts.UserAgent;
@@ -111,8 +107,7 @@ namespace CsQuery.Web
 
             get
             {
-                return Timeout==null ? 0 :
-                    Timeout.TotalSeconds;
+                return Timeout.TotalSeconds;
             }
             set
             {


### PR DESCRIPTION
Often when you are querying / manipulating the DOM, you would like to associate data you collect / compute as you traverse the DOM for later consumption.  This pull request adds an Annotations collection to the IDomObject interface and DomObject implementation to allow arbitrary annotations (key/value pairs) to be associated with DOM objects.

Thoughts?
