### PR TITLE
Added Attribute Regex Replace

### DIFF
--- a/source/CsQuery.Tests/CQ_CsQuery/AttrReplace.cs
+++ b/source/CsQuery.Tests/CQ_CsQuery/AttrReplace.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+using CsQuery;
+
+
+namespace CsQuery.Tests.CQ_CsQuery 
+{
+    [TestClass,TestFixture]
+    public class AttrReplace : CsQueryTest 
+    {
+
+        [TestMethod, Test]
+        public void Substring() 
+        {
+            var expected = CQ.Create("<p class=\"two\"></p>");
+            var cq = CQ.Create("<p class=\"one\"></p>");
+
+            Assert.AreEqual(expected, cq.AttrReplace("class", "one", "two"));
+        }
+
+        [TestMethod, Test]
+        public void Regex() {
+            var expected = CQ.Create("<p style=\"\"></p>");
+            var cq = CQ.Create("<p style=\"font-size: 10px;\"></p>");
+
+            Assert.AreEqual(expected, cq.AttrRegexReplace("style", @"font-size:\s+\d+px;?", ""));
+        }
+
+        [TestMethod, Test]
+        public void Regex_Evaluated() {
+            var expected = CQ.Create("<p style=\"font-size: 20px;\"></p>");
+            var cq = CQ.Create("<p style=\"font-size: 10px;\"></p>");
+
+            Assert.AreEqual(expected, cq.AttrRegexReplace("style", @"font-size:\s+(\d+)px;?", (m) => {
+                return m.Captures[0].Value.Replace(m.Groups[1].Value, "20");
+            }));
+        }
+    }
+}

--- a/source/CsQuery.Tests/Csquery.Tests.csproj
+++ b/source/CsQuery.Tests/Csquery.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Core\Methods\Data.cs" />
     <Compile Include="Core\Selectors\ContentIsNotNumeric.cs" />
     <Compile Include="Core\WebIO\BasicWeb.cs" />
+    <Compile Include="CQ_CsQuery\AttrReplace.cs" />
     <Compile Include="ExtensionMethods\Xml.cs" />
     <Compile Include="HtmlParser\Button.cs" />
     <Compile Include="HtmlParser\CharacterSetEncoding.cs" />

--- a/source/CsQuery/CQ_CsQuery/AttrReplace.cs
+++ b/source/CsQuery/CQ_CsQuery/AttrReplace.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using CsQuery.Utility;
 using CsQuery.ExtensionMethods;
 using CsQuery.ExtensionMethods.Internal;
@@ -40,6 +41,64 @@ namespace CsQuery
                 if (val != null)
                 {
                     item[name] = val.Replace(replaceWhat, replaceWith);
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Perform a regex replace on the contents of the named attribute in each item in the
+        /// selection set.
+        /// </summary>
+        ///
+        /// <param name="name">
+        /// The attribute name.
+        /// </param>
+        /// <param name="pattern">
+        /// The regex pattern.
+        /// </param>
+        /// <param name="replaceWith">
+        /// The value to replace each occurrence with.
+        /// </param>
+        ///
+        /// <returns>
+        /// The current CQ object.
+        /// </returns>
+
+        public CQ AttrRegexReplace(string name, string pattern, string replaceWith) {
+            foreach (IDomElement item in SelectionSet) {
+                string val = item[name];
+                if (val != null) {
+                    item[name] = Regex.Replace(val, pattern, replaceWith);
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Perform a regex replace on the contents of the named attribute in each item in the
+        /// selection set.
+        /// </summary>
+        ///
+        /// <param name="name">
+        /// The attribute name.
+        /// </param>
+        /// <param name="pattern">
+        /// The regex pattern.
+        /// </param>
+        /// <param name="matchEvaluator">
+        /// The evaluator used to replace the pattern
+        /// </param>
+        ///
+        /// <returns>
+        /// The current CQ object.
+        /// </returns>
+
+        public CQ AttrRegexReplace(string name, string pattern, MatchEvaluator matchEvaluator) {
+            foreach (IDomElement item in SelectionSet) {
+                string val = item[name];
+                if (val != null) {
+                    item[name] = Regex.Replace(val, pattern, matchEvaluator);
                 }
             }
             return this;


### PR DESCRIPTION
Regex replace for attributes would be very useful for replacing inline styles. For example, It is not currently possible to replace a font-size or font-family inline style unless you can guarantee the values.

Using regex on HTML is very problematic. However, using regex on an attribute value works nicely.
